### PR TITLE
feat: save output in multiple files for readability

### DIFF
--- a/examples/config/result_save/default.yaml
+++ b/examples/config/result_save/default.yaml
@@ -1,0 +1,3 @@
+architecture:
+  _target_: llm_synthesis.result_gather.synthesis_results.fs_result_gather.SynthesisFSResultGather
+  result_dir: "results"

--- a/src/llm_synthesis/result_gather/__init__.py
+++ b/src/llm_synthesis/result_gather/__init__.py
@@ -1,0 +1,3 @@
+from llm_synthesis.result_gather.synthesis_results.fs_result_gather import (
+    SynthesisFSResultGather,
+)

--- a/src/llm_synthesis/result_gather/base.py
+++ b/src/llm_synthesis/result_gather/base.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class ResultGatherInterface(ABC, Generic[T]):
+    @abstractmethod
+    def gather(self, paper: T):
+        """
+        Gather the results of the paper.
+        """
+        pass

--- a/src/llm_synthesis/result_gather/synthesis_results/fs_result_gather.py
+++ b/src/llm_synthesis/result_gather/synthesis_results/fs_result_gather.py
@@ -1,0 +1,46 @@
+import json
+import os
+
+import fsspec
+
+from llm_synthesis.models.paper import PaperWithSynthesisOntology
+from llm_synthesis.result_gather.base import ResultGatherInterface
+
+
+class SynthesisFSResultGather(
+    ResultGatherInterface[PaperWithSynthesisOntology]
+):
+    def __init__(self, result_dir: str = ""):
+        self.result_dir = result_dir
+        self.fs, _, _ = fsspec.get_fs_token_paths(self.result_dir)
+        self._ensure_dir(self.result_dir)
+
+    def gather(self, paper: PaperWithSynthesisOntology):
+        self._ensure_dir(os.path.join(self.result_dir, paper.id))
+        with self.fs.open(
+            os.path.join(self.result_dir, paper.id, "result.json"), "w"
+        ) as f:
+            f.write(
+                json.dumps(paper.synthesis_ontology.model_dump(), indent=2)
+            )
+        with self.fs.open(
+            os.path.join(self.result_dir, paper.id, "synthesis_paragraph.txt"),
+            "w",
+        ) as f:
+            f.write(paper.synthesis_paragraph)
+
+        with self.fs.open(
+            os.path.join(self.result_dir, paper.id, "publication_text.txt"),
+            "w",
+        ) as f:
+            f.write(paper.publication_text)
+
+        with self.fs.open(
+            os.path.join(self.result_dir, paper.id, "si_text.txt"),
+            "w",
+        ) as f:
+            f.write(paper.si_text)
+
+    def _ensure_dir(self, dir: str):
+        if not self.fs.exists(dir):
+            self.fs.makedirs(dir)


### PR DESCRIPTION
Hi there!

This PR is created to save the output of the LLM pipeline in a convenient format: saving the publication text and si text, syntesis paragraph and synthesis ontology separately.
When we move forward to also save figure data, this will be saved in another folder

The reason is to keep the "results.json" file reasonably small and human readable. That way, we will also directly parse the output from the results.json and compare it to some annotated ground truth.

I guess the class PaperWithSynthesisOntology will come in handy when we write the full benchmark script!

Tagging @gregoiregermain for this for best practices I might have missed