### PR TITLE
fix(scripts): Resolve configuration and import errors

### DIFF
--- a/examples/config/config.yaml
+++ b/examples/config/config.yaml
@@ -5,6 +5,10 @@ defaults:
   - synthesis_extraction: default
   - paragraph_extraction: default
   - judge: default
+  # Added `result_save` to the defaults list. This was missing and caused a
+  # `ConfigAttributeError` because the script needs this configuration to know
+  # how to save the results.
+  - result_save: default
 
 # Dir handling
 hydra:

--- a/examples/scripts/extract_synthesis_procedure_from_text.py
+++ b/examples/scripts/extract_synthesis_procedure_from_text.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import hydra
 from hydra.utils import get_original_cwd, instantiate


### PR DESCRIPTION
This commit addresses two issues that caused the extraction script to crash:
- Adds the missing 'import os' statement in 'extract_synthesis_procedure_from_text.py' to resolve a NameError.
- Updates 'config.yaml' to include the 'result_save' configuration by default, which fixes a Hydra ConfigAttributeError.