### PR TITLE
feat: remove No materials synthesized entries from HF dataset

### DIFF
--- a/examples/scripts/remove_unsuccessful_hf_entries.py
+++ b/examples/scripts/remove_unsuccessful_hf_entries.py
@@ -1,0 +1,29 @@
+import logging
+
+from datasets import Dataset, load_dataset
+
+logging.basicConfig(level=logging.INFO)
+
+
+def main():
+    dataset = load_dataset("LeMaterial/LeMat-Synth")
+    splits = dataset.keys()
+
+    for split in splits:
+        cts = 0
+        df = dataset[split].to_pandas()
+        len_of_df_before = len(df)
+        for index, row in df.iterrows():
+            if row["synthesized_material"] == "No materials synthesized":
+                cts += 1
+                df = df.drop(index)
+        dataset[split] = Dataset.from_pandas(df)
+        perc = cts / len_of_df_before * 100
+        logging.info(f"Split: {split}")
+        logging.info(f"Number of unsuccessful entries: {cts} ({perc:.2f}%)")
+
+    dataset.push_to_hub("LeMaterial/LeMat-Synth", create_pr=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This script introduces a simple filter to remove "empty" synthesis recipes. In our case, 20 samples (corresponding to 3.4%) are removed. I also created a PR on HF. This script should be executed after every push of new synthesis recipes from the extraction script ("post processing filter").

The script is very bare-bones right now, but should work. Could you kindly review @georgia-hf , @georgiachanning  ? thank you!

<img width="926" height="58" alt="image" src="https://github.com/user-attachments/assets/d5c495e4-d3b5-4eb0-a364-4ead69981d5e" />
