### PR TITLE
fix(deps): investigate Dependabot alerts (litellm), tidy dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,9 @@ dependencies = [
     "google-genai>=1.63.0",
     "hydra-core>=1.3.2",
     "jupyterlab>=4.4.2",
-    "litellm>=1.83.7,<1.84",
+    "litellm>=1.89.2",
     "matplotlib>=3.10.3",
     "mistralai>=1.7.0",
-    "nltk>=3.9.4",
     "pandas>=2.2.3",
     "peft>=0.18.1",
     "pingouin>=0.5.5",
@@ -58,6 +57,7 @@ dev = [
     "ipython>=9.2.0",
     "ipywidgets>=8.1.7",
     "pre-commit>=4.2.0",
+    "nltk>=3.9.4",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2653,7 +2653,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.14"
+version = "1.89.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2669,9 +2669,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/29/865d38325f9c424daf0bcc7ab61908cf51a87862b3a0dfebd059b60dac97/litellm-1.89.2.tar.gz", hash = "sha256:b2534d69568eed026310f4e006407db2d46494eb629bd1e71eb9603ec146540d", size = 14079449, upload-time = "2026-06-18T02:26:03.64Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
+    { url = "https://files.pythonhosted.org/packages/32/c8/51c93e8d017e7af02600171b5b6cc3805b07507acb2b94de7235ce764015/litellm-1.89.2-py3-none-any.whl", hash = "sha256:07e8e43b1a70fe919021376742897d18ffe7577ccfbb84632c949670f9abdc03", size = 15492797, upload-time = "2026-06-18T02:25:59.863Z" },
 ]
 
 [[package]]
@@ -2693,7 +2693,6 @@ dependencies = [
     { name = "litellm" },
     { name = "matplotlib" },
     { name = "mistralai" },
-    { name = "nltk" },
     { name = "pandas" },
     { name = "peft" },
     { name = "pingouin" },
@@ -2722,6 +2721,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "nbstripout" },
+    { name = "nltk" },
     { name = "pre-commit" },
     { name = "ruff" },
 ]
@@ -2739,10 +2739,9 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.63.0" },
     { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "jupyterlab", specifier = ">=4.4.2" },
-    { name = "litellm", specifier = ">=1.83.7,<1.84" },
+    { name = "litellm", specifier = ">=1.89.2" },
     { name = "matplotlib", specifier = ">=3.10.3" },
     { name = "mistralai", specifier = ">=1.7.0" },
-    { name = "nltk", specifier = ">=3.9.4" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "peft", specifier = ">=0.18.1" },
     { name = "pingouin", specifier = ">=0.5.5" },
@@ -2771,6 +2770,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.25" },
     { name = "nbstripout", specifier = ">=0.8.1" },
+    { name = "nltk", specifier = ">=3.9.4" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "ruff", specifier = ">=0.12.8" },
 ]


### PR DESCRIPTION
Investigates the Dependabot vulnerable-dependency alerts (#268).

- `litellm`: bump 1.83.14 -> 1.89.2 to clear the Critical advisory. The previous `<1.84` upper bound was Dependabot's auto-maintained next-minor cap (was `<1.82`), not a compatibility constraint, and was what blocked the security fix from landing. Cap removed so future patches aren't held back the same way.
- `nltk`: moved from runtime dependencies to the `dev` group. It is only used by a dev analysis notebook (examples/notebooks/dev/Data_Analysis_LeMat_Papers.ipynb), not by the package itself.
- `cryptography` is a transitive dependency (`google-auth` <- `gcsfs` / `google-genai`) and is already pinned to the latest published 49.0.0; `nltk` is likewise already at the latest 3.9.4. Their alerts might close once Dependabot re-scans this updated lock.

NOTE: `timm`, `pymupdf`, `einops` and `fastapi` appear to be unused (no imports in the codebase, not depended on by anything else), but are intentionally left in place for now, pending confirmation rather than removed.