### PR TITLE
feat(evaluation): include --rank-by in judge-ranking output filenames

### DIFF
--- a/examples/scripts/evaluation/compare_multi_llm_results_complete.py
+++ b/examples/scripts/evaluation/compare_multi_llm_results_complete.py
@@ -513,20 +513,13 @@ def _save_ranking_png(ranked, rank_by):
         fontweight="bold",
         pad=20,
     )
-    out_png = os.path.join(OUTPUT_DIR, "multi_llm_judge_ranking.png")
+    out_png = os.path.join(OUTPUT_DIR, f"multi_llm_judge_ranking_{rank_by}.png")
     plt.savefig(out_png, dpi=300, bbox_inches="tight", facecolor="white")
     plt.close()
     return out_png
 
 
 def main():
-    os.makedirs(OUTPUT_DIR, exist_ok=True)
-    logging.basicConfig(
-        filename=os.path.join(OUTPUT_DIR, "multi_llm_complete.log"),
-        level=logging.INFO,
-        force=True,
-        filemode="w",
-    )
     parser = argparse.ArgumentParser(
         description="Compare multi-LLM results with human annotations",
     )
@@ -538,6 +531,16 @@ def main():
         help="Metric to rank judges by (default: abs_diff)",
     )
     args = parser.parse_args()
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    logging.basicConfig(
+        filename=os.path.join(
+            OUTPUT_DIR, f"multi_llm_complete_{args.rank_by}.log"
+        ),
+        level=logging.INFO,
+        force=True,
+        filemode="w",
+    )
 
     # same as compare_human_judge_scores_complete.py
     skip_folders = [
@@ -575,7 +578,9 @@ def main():
     synth_judge_heatmap(human_df, llm_df)
 
     # Save JSON
-    out_json = os.path.join(OUTPUT_DIR, "multi_llm_judge_ranking.json")
+    out_json = os.path.join(
+        OUTPUT_DIR, f"multi_llm_judge_ranking_{args.rank_by}.json"
+    )
     with open(out_json, "w", encoding="utf-8") as fh:
         json.dump(
             [
@@ -591,10 +596,12 @@ def main():
     out_png = _save_ranking_png(ranked, args.rank_by)
 
     logging.info(
-        "\nSaved judge ranking to %s and %s | Log at %s/multi_llm_complete.log",
+        "\nSaved judge ranking to %s and %s | "
+        "Log at %s/multi_llm_complete_%s.log",
         out_json,
         out_png,
         OUTPUT_DIR,
+        args.rank_by,
     )
 
 


### PR DESCRIPTION
## Summary

Running `compare_multi_llm_results_complete.py` with different `--rank-by` values overwrote its own outputs, because the log, ranking JSON, and ranking PNG all used fixed filenames. This makes it impossible to keep, say, the `icc2`-sorted and `abs_diff`-sorted rankings side by side. This PR suffixes those three outputs with the `rank_by` value so each sorting is preserved.

## What changed

Single file: `examples/scripts/evaluation/compare_multi_llm_results_complete.py`.

- Output filenames now include `rank_by`:
  - `multi_llm_complete.log` → `multi_llm_complete_<rank_by>.log`
  - `multi_llm_judge_ranking.json` → `multi_llm_judge_ranking_<rank_by>.json`
  - `multi_llm_judge_ranking.png` → `multi_llm_judge_ranking_<rank_by>.png`
- Moved argument parsing above `logging.basicConfig` so `args.rank_by` is available when the log filename is built.
- Updated the final "Saved…" log line to report the parameterized log name.
- Left the heatmap (`multi_llm_heatmap_synth_judge.png`) unchanged: it is always computed on `abs_diff` and is independent of `--rank-by`, so parameterizing it would only create identical copies.

## Why

`--rank-by` only changes the sort order of the same set of judge metrics; every metric is computed on every run. Users comparing sortings (e.g. `icc2` vs `abs_diff`) previously lost the earlier run's files. Distinct filenames let the runs coexist without manual copying.

## Verification

```bash
uv run python examples/scripts/evaluation/compare_multi_llm_results_complete.py --rank-by icc2
uv run python examples/scripts/evaluation/compare_multi_llm_results_complete.py --rank-by abs_diff
ls results/agreement_analysis/
```

Both runs' artifacts are present side by side:

```
multi_llm_complete_abs_diff.log
multi_llm_complete_icc2.log
multi_llm_judge_ranking_abs_diff.json
multi_llm_judge_ranking_abs_diff.png
multi_llm_judge_ranking_icc2.json
multi_llm_judge_ranking_icc2.png
multi_llm_heatmap_synth_judge.png   # single, rank_by-independent
```

`uvx ruff check` passes on the modified file.

## Notes

- No behavioral change to the metrics or rankings themselves — only output filenames.
- `compare_multi_llm_results_by_category.py` is unaffected (it has no `--rank-by`).
